### PR TITLE
Add redux boiler plate and wrap app in provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
+    "react-redux": "^7.1.1",
     "redux": "^4.0.4",
     "semantic-ui-react": "^0.87.3",
     "styled-components": "^4.3.2"
@@ -26,6 +27,7 @@
     "@types/node": "^12.7.2",
     "@types/react": "^16.9.2",
     "@types/react-dom": "^16.9.0",
+    "@types/react-redux": "^7.1.2",
     "@types/styled-components": "^4.1.18",
     "@types/webpack": "^4.4.35",
     "@types/webpack-dev-server": "^3.1.7",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -3,6 +3,9 @@ import { Container } from "semantic-ui-react";
 import { Stories } from "./Stories";
 import { Title } from "./Title";
 import ViewSwitchButton from "./ViewSwitchButton";
+import { createStore } from "redux";
+import { Provider } from "react-redux";
+import { appReducer } from "../store/configureStore";
 
 export const enum View {
   list,
@@ -20,14 +23,16 @@ export class App extends React.PureComponent {
 
   public render(): JSX.Element {
     return (
-      <Container style={{ marginTop: "3em", marginBottom: "3em" }}>
-        <Title title="Hacker News Clone" />
-        <ViewSwitchButton
-          view={this.state.view}
-          onClick={this.toggleStoryView}
-        />
-        <Stories view={this.state.view} />
-      </Container>
+      <Provider store={createStore(appReducer)}>
+        <Container style={{ marginTop: "3em", marginBottom: "3em" }}>
+          <Title title="Hacker News Clone" />
+          <ViewSwitchButton
+            view={this.state.view}
+            onClick={this.toggleStoryView}
+          />
+          <Stories view={this.state.view} />
+        </Container>
+      </Provider>
     );
   }
 

--- a/src/store/configureStore.ts
+++ b/src/store/configureStore.ts
@@ -1,47 +1,96 @@
-import { Action, ActionCreator, createStore } from "redux";
+import { Action, ActionCreator, combineReducers } from "redux";
+import { StoryRaw } from "../common/api";
 
 // action
-export const enum CounterTypes {
-  INCREMENT = "INCREMENT",
-  DECREMENT = "DECREMENT"
+export const enum StoriesTypes {
+  REFRESH = "REFRESH"
 }
 
-const initialCounterState: CounterState = {
-  counter: 0
+export const enum NumberOfStoriesTypes {
+  INCREMENT = "INCREMENT",
+  DECREMENT = "DECREMENT",
+  SET = "SET"
+}
+
+const initialState: State = {
+  numberOfStories: 10,
+  stories: []
 };
 
-const counterApp = (
-  state: CounterState = initialCounterState,
-  { type }: CounterAction
-): CounterState => {
+const stories = (
+  state: State = initialState,
+  { type }: StoriesAction
+): State => {
   switch (type) {
-    case CounterTypes.INCREMENT:
-      return { ...state, counter: state.counter + 1 };
-    case CounterTypes.DECREMENT:
-      return { ...state, counter: state.counter - 1 };
+    case StoriesTypes.REFRESH:
+      return { ...state, stories: [] };
+    default:
+      return state;
   }
-  return state;
 };
+
+const numberOfStories = (
+  state: State = initialState,
+  action: NumberOfStoriesAction
+): State => {
+  switch (action.type) {
+    case NumberOfStoriesTypes.INCREMENT:
+      return { ...state, numberOfStories: state.numberOfStories + 1 };
+    case NumberOfStoriesTypes.DECREMENT:
+      return { ...state, numberOfStories: state.numberOfStories - 1 };
+    case NumberOfStoriesTypes.SET:
+      return { ...state, numberOfStories: action.number };
+    default:
+      return state;
+  }
+};
+
+export const appReducer = combineReducers({ stories, numberOfStories });
 
 // action creator
-export const incrementCount: ActionCreator<IncrementCounterAction> = () => ({
-  type: CounterTypes.INCREMENT
+export const refreshStories: ActionCreator<RefreshStoriesAction> = () => ({
+  type: StoriesTypes.REFRESH
 });
 
-export const decrementCount: ActionCreator<DecrementCounterAction> = () => ({
-  type: CounterTypes.DECREMENT
+export const incrementNumberOfStories: ActionCreator<
+  IncrementNumberOfStoriesAction
+> = () => ({
+  type: NumberOfStoriesTypes.INCREMENT
+});
+export const decrementNumberOfStories: ActionCreator<
+  DecrementNumberOfStoriesAction
+> = () => ({
+  type: NumberOfStoriesTypes.DECREMENT
+});
+export const setNumberOfStories: ActionCreator<SetNumberOfStoriesAction> = (
+  number: number
+) => ({
+  type: NumberOfStoriesTypes.SET,
+  number: number
 });
 
-type CounterAction = IncrementCounterAction | DecrementCounterAction;
+type StoriesAction = RefreshStoriesAction;
+type NumberOfStoriesAction =
+  | IncrementNumberOfStoriesAction
+  | DecrementNumberOfStoriesAction
+  | SetNumberOfStoriesAction;
 
-interface IncrementCounterAction extends Action {
-  type: CounterTypes.INCREMENT;
+interface RefreshStoriesAction extends Action {
+  type: StoriesTypes.REFRESH;
 }
 
-interface DecrementCounterAction extends Action {
-  type: CounterTypes.DECREMENT;
+interface IncrementNumberOfStoriesAction extends Action {
+  type: NumberOfStoriesTypes.INCREMENT;
+}
+interface DecrementNumberOfStoriesAction extends Action {
+  type: NumberOfStoriesTypes.DECREMENT;
+}
+interface SetNumberOfStoriesAction extends Action {
+  type: NumberOfStoriesTypes.SET;
+  number: number;
 }
 
-interface CounterState {
-  readonly counter: number;
+interface State {
+  readonly numberOfStories: number;
+  readonly stories: StoryRaw[];
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -112,7 +112,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/runtime@^7.1.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
   integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
@@ -444,6 +444,14 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/html-minifier@*":
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/@types/html-minifier/-/html-minifier-3.5.3.tgz#5276845138db2cebc54c789e0aaf87621a21e84f"
@@ -554,6 +562,16 @@
   dependencies:
     "@types/prop-types" "*"
     "@types/react" "*"
+
+"@types/react-redux@^7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.2.tgz#02303b77d87e54f327c09507cf80ee3ca3063898"
+  integrity sha512-Iim6UCtD0mZX9U3jBuT6ZObBZ8UlakoOgefiRgi5wakfbNnXd3TUwwUMgi3Ijc0fxsPLZ5ULoz0oDy15YIaLmQ==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
 
 "@types/react@*", "@types/react@^16.9.2":
   version "16.9.2"
@@ -3173,6 +3191,13 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+hoist-non-react-statics@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
+  integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
+  dependencies:
+    react-is "^16.7.0"
+
 homedir-polyfill@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
@@ -5539,7 +5564,7 @@ react-dom@^16.9.0:
     prop-types "^15.6.2"
     scheduler "^0.15.0"
 
-react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
@@ -5555,6 +5580,18 @@ react-popper@^1.3.3:
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
     warning "^4.0.2"
+
+react-redux@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.1.1.tgz#ce6eee1b734a7a76e0788b3309bf78ff6b34fa0a"
+  integrity sha512-QsW0vcmVVdNQzEkrgzh2W3Ksvr8cqpAv5FhEk7tNEft+5pp7rXxAudTz3VOPawRkLIepItpkEIyLcN/VVXzjTg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    hoist-non-react-statics "^3.3.0"
+    invariant "^2.2.4"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.9.0"
 
 react@^16.9.0:
   version "16.9.0"
@@ -5620,7 +5657,7 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-redux@^4.0.4:
+redux@^4.0.0, redux@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.4.tgz#4ee1aeb164b63d6a1bcc57ae4aa0b6e6fa7a3796"
   integrity sha512-vKv4WdiJxOWKxK0yRoaK3Y4pxxB0ilzVx6dszU2W8wLxlb2yikRph4iV/ymtdJ6ZxpBLFbyrxklnT5yBbQSl3Q==


### PR DESCRIPTION
Not actually using redux in the application logic at this point, but the structure is in place now for implementing fetching stories from the api, and for the components to have access to the store via `react-redux`.